### PR TITLE
Fix: add homepage to urls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 dependencies = []
 
 [project.urls]
+Homepage = "https://github.com/pypa/sampleproject"
 Documentation = "https://github.com/pyopensci/pyospackage#readme"
 Issues = "https://github.com/pyopensci/pyospackage/issues"
 Source = "https://github.com/pyopensci/pyospackage"


### PR DESCRIPTION
This adds. homepage to our pyproject.toml. i'll now try to rebuild the package recipe with grayskull 