### PR TITLE
Fix: changelog didn't sync with pypi version

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,14 @@
 
 * Fix: Drop support for python 3.9, add for 3.12 (@lwasser, #15)
 
+## 0.1.10
+
+* Initial publish to PyPI & Conda forge 
+
+## 0.1.9
+
+* Use Hatch
+
 ## 0.1.8
 
 * Fix: License should be MIT throughout


### PR DESCRIPTION
This is a big of a hacky PR. I think what happened is when I was playing with Hatch and publishing to pypi / conda-forge i incremented the version a few times. So now it's at 1.10 but the changelog was only at 1.08. So i just bumped up the changelog so we are fully in sync. 