### PR TITLE
Add: documentation to package

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,10 @@ release = "1.10"
 # Extensions add additional functionality to your documentation.
 # TODO: describe each extension below
 extensions = [
+    # Autodoc will create API docs for you
+    # "sphinx.ext.autodoc", # This is the older autodoc that doesn't support myst
+    "autodoc2",  # Supports myst markdown, ugly output
+    "autoapi.extension",
     "sphinx_design",
     "sphinx_copybutton",
     "sphinx.ext.intersphinx",
@@ -64,3 +68,11 @@ myst_footnote_transition = False
 
 html_theme = "pydata_sphinx_theme"
 html_static_path = ["_static"]
+
+# Autodoc
+# autodoc2_render_plugin = "myst"
+# autodoc2_packages = [
+#     "../src/pyospackage",
+# ]
+
+autoapi_dirs = ["../src/pyospackage"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,66 @@
+# Below we grab the current date and time using python
+# this is used to them support the copyright date always being the current year
+# when you build your docs
+import subprocess
+from datetime import datetime
+
+current_year = datetime.now().year
+organization_name = "pyOpenSci"
+
+
+project = "pyosPackage"
+copyright = f"{current_year}, {organization_name}"
+author = "pyOpenSci Community"
+
+# *********** RELEASE NUMBER **************
+# This is optional - if you want the release of your docs to align with your
+# package release cycle then the code below will get the recent tag and use
+# that to generate your documentation release value.
+try:
+    release_value = (
+        subprocess.check_output(["git", "describe", "--tags"])
+        .decode("utf-8")
+        .strip()
+    )
+    release_value = release_value[:4]
+except subprocess.CalledProcessError:
+    release_value = "0.1"  # Default value in case there's no tag
+
+# Update the release value
+release = release_value
+
+
+release = "1.10"
+
+# -- General configuration ---------------------------------------------------
+# Extensions add additional functionality to your documentation.
+# TODO: describe each extension below
+extensions = [
+    "sphinx_design",
+    "sphinx_copybutton",
+    "sphinx.ext.intersphinx",
+    # This allows you to create :::{todo} sections that will not be rendered
+    # in the live docs
+    "sphinx.ext.todo",
+    "myst_parser",
+]
+
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# ****** setup MYST ******
+# colon fence for card support in md
+myst_enable_extensions = [
+    "colon_fence",
+    "deflist",
+    "attrs_block",
+]
+myst_heading_anchors = 3
+myst_footnote_transition = False
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "pydata_sphinx_theme"
+html_static_path = ["_static"]

--- a/docs/documentation/setup-sphinx.md
+++ b/docs/documentation/setup-sphinx.md
@@ -1,0 +1,51 @@
+# Sphinx documentation
+
+This package uses Sphinx to create documentation.
+
+We like sphinx because it is a community driven project with a community
+driven theme that the scientific Python community works on:
+
+`pydata_sphinx_theme`
+
+:::{note}
+MkDocs is the other most common documentation tool used in the Python
+ecosystem.
+:::
+
+## Setup your documentation
+
+You can chose to create sphinx documentation using sphinx-quickstart.
+Below is the Sphinx-quickstart workflow used to create these docs. However,
+inevitably you will likely customize the documentation setup. So you may also
+want to just copy this repository's structure.
+
+```
+➜ sphinx-quickstart
+Welcome to the Sphinx 5.3.0 quickstart utility.
+
+Please enter values for the following settings (just press Enter to
+accept a default value, if one is given in brackets).
+
+Selected root path: .
+
+You have two options for placing the build directory for Sphinx output.
+Either, you use a directory "_build" within the root path, or you separate
+"source" and "build" directories within the root path.
+> Separate source and build directories (y/n) [n]: n
+
+The project name will occur in several places in the built documentation.
+> Project name: pyosPackage
+> Author name(s): pyOpenSci Community
+> Project release []: 1.10
+
+If the documents are to be written in a language other than English,
+you can select a language here by its language code. Sphinx will then
+translate text that it generates into that language.
+
+For a list of supported codes, see
+https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language.
+> Project language [en]: en
+```
+
+The `conf.py` file is the core that you use to configure your sphinx docs.
+The conf.py file in this package is setup

--- a/docs/documentation/setup-sphinx.md
+++ b/docs/documentation/setup-sphinx.md
@@ -19,14 +19,14 @@ Below is the Sphinx-quickstart workflow used to create these docs. However,
 inevitably you will likely customize the documentation setup. So you may also
 want to just copy this repository's structure.
 
-```
+```bash
 ➜ sphinx-quickstart
 Welcome to the Sphinx 5.3.0 quickstart utility.
 
 Please enter values for the following settings (just press Enter to
 accept a default value, if one is given in brackets).
 
-Selected root path: .
+Selected root path: docs
 
 You have two options for placing the build directory for Sphinx output.
 Either, you use a directory "_build" within the root path, or you separate
@@ -47,5 +47,21 @@ https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language.
 > Project language [en]: en
 ```
 
-The `conf.py` file is the core that you use to configure your sphinx docs.
-The conf.py file in this package is setup
+## About the conf.py file
+
+The `conf.py` file is what Sphinx uses to configure your documentation. This is
+where you setup all of the features that you want your documentation to have.
+
+:::{note}
+Every tool and theme that you might use will have different configuration options
+that will be placed in the `conf.py` file.
+:::
+
+## API / Reference documentation
+
+It's useful to have a reference section in your docs that contains documentation
+for your package's methods and classes. In this demo package we are using
+autodoc2 which will create these reference docs for you automatically.
+
+We like `autodoc2` over `sphinx_autodoc` extension because it supports `myst`
+markdown.

--- a/docs/hatch-envs-scripts.md
+++ b/docs/hatch-envs-scripts.md
@@ -1,0 +1,34 @@
+# Hatch scripts and environments
+
+* Hatch has a nox / tox / make like feature that allows you to:
+
+1. Define `Python` environments with a set of tools that you wish to have installed.
+2. Define commands that you wish to run in that environment.
+
+All of the configuration for this goes into your `pyproject.toml` file.
+
+## How to set this up
+
+To set this up you first need to define an environment in your `pyproject.toml`
+with all of the dependencies that the environment needs.
+
+Below you can see we have defined an environment called `docs`.
+
+:::{literalinclude} ../pyproject.toml
+:language: toml
+:start-at: [tool.hatch.envs.docs]
+:end-before: [tool.hatch.envs.docs.scripts]
+:::
+
+Once you have an environment setup, you can then create commands that you wish
+hatch to run for you within that environment. Below you setup two commands:
+
+1. Build sphinx docs using the `sphinx-build` command.
+2. Build sphinx docs in "live" mode which allows them to be updated every time
+that you save
+
+:::{literalinclude} ../pyproject.toml
+:language: toml
+:start-at: [tool.hatch.envs.docs.scripts]
+:end-before: [tool.hatch.envs.test]
+:::

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,32 @@
+# Welcome to pyosPackage's documentation
+
+:::{toctree}
+:maxdepth: 2
+:caption: Contents:
+
+home <self>
+hatch scripts <hatch-envs-scripts>
+Setup Sphinx <documentation/setup-sphinx>
+:::
+
+:::{toctree}
+:maxdepth: 2
+:caption: Contents:
+
+:::
+
+This guidebook uses myst as the primary documentation syntax.
+
+more about myst here....
+
+If you see syntax like the syntax below, you are looking at rst.
+
+```
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+```
+
+:::{note}
+you can remove the `make.bat` and `Makefile` files included with sphinx build.
+:::

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@
 home <self>
 hatch scripts <hatch-envs-scripts>
 Setup Sphinx <documentation/setup-sphinx>
+Reference / API <apidocs/index>
 :::
 
 :::{toctree}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,30 @@ Issues = "https://github.com/pyopensci/pyospackage/issues"
 Source = "https://github.com/pyopensci/pyospackage"
 
 
+[tool.hatch.envs.docs]
+dependencies = [
+  "sphinx",
+  "sphinx-autobuild",
+  "sphinx-inline-tabs",
+  # Note that the tool you install has dashes- between the name, vs _underscores
+  # when you call the theme in sphinx's conf.py
+  "pydata-sphinx-theme",
+  "sphinx-design",
+  "sphinx-copybutton",
+  "myst-nb",
+  "myst-parser",
+]
+
+
+[tool.hatch.envs.docs.scripts]
+# Build your docs statically - html output
+# hatch run docs:docs-html
+docs-html = "sphinx-build docs/ docs/_build"
+# hatch run docs:docs-html
+docs-live = "sphinx-autobuild docs/ docs/_build"
+# TODO: add step to clean docs directory
+
+
 [tool.hatch.envs.test]
 dependencies = [
   "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ dependencies = [
   "sphinx-copybutton",
   "myst-nb",
   "myst-parser",
+  "sphinx-autoapi",
+  # Autodoc2 supports myst mardown
+  #"sphinx-autodoc2"
 ]
 
 

--- a/src/pyospackage/add_numbers.py
+++ b/src/pyospackage/add_numbers.py
@@ -5,4 +5,18 @@ def add_num(
     a: int,
     b: int,
 ) -> int:
+    """A function that adds two  numbers together
+
+    Parameters
+    ----------
+    a : int
+        The first integer to be added.
+    b : int
+        The second integer to be added.
+
+    Returns
+    -------
+    int
+        The sum of the two provided integers.
+    """
     return a + b


### PR DESCRIPTION
closes #18 

This is a basic representation of documentation. I am going to add API docs next and then merge it. it needs a lot of work but the point is more about the setup - eventually we will flesh out the docs to explain each part of this package. 