### PR TITLE
docs: format code snippets as blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,15 @@ whatever environment manager that you wish!
 
 To install the package using pip:
 
-`pip install pyospackage`
+```shell
+pip install pyospackage
+```
 
 To install the package using conda-forge:
 
-`conda install -c conda-forge pyospackage`
+```shell
+conda install -c conda-forge pyospackage
+```
 
 ## Get started using packagename
 


### PR DESCRIPTION
Working on #56 , I noticed some commands in the README that are formatted as inline markup.

This proposes switching them to code blocks, so people following along will get a "copy to clipboard" button and not need to manually snip by clicking and dragging.

**Before**

<img width="798" height="256" alt="image" src="https://github.com/user-attachments/assets/f2d24aea-73b3-4f59-8850-485f35ceb9ce" />

**After**

<img width="815" height="307" alt="Screenshot 2025-07-12 at 10 22 50 AM" src="https://github.com/user-attachments/assets/61e6b2a4-b6a7-4d4f-87af-3663b9afc27a" />

Thanks for your time and consideration.