### PR TITLE
docs: Add template info and packaging tutorial links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,17 @@ pyospackage is a demonstration Python package that compliments the pyOpenSci [be
 
 ## 🔧 About This Template
 
-This package was built using [pyOpenSci’s Copier template](https://github.com/pyOpenSci/pyos-template), which helps ensure consistency, best practices, and ease of maintenance across scientific Python packages.
+This package was built using [pyOpenSci’s Python package Copier template](https://github.com/pyOpenSci/pyos-package-template).l This template makes it easy for anyone to quickly create a Python package following best practices developed by the pyOpenSci community.
 
 The template includes configuration for:
-- Standard Python packaging layout
-- Code linting and formatting tools like Ruff
-- Testing setup
-- CI/CD scaffolding
-- Contribution guidelines
+* [Standard Python package layout and structure](https://www.pyopensci.org/python-package-guide/package-structure-code/python-package-structure.html)
+* [Code linting and formatting tools like Ruff](https://www.pyopensci.org/python-package-guide/package-structure-code/code-style-linting-format.html)
+* [Setup for a test suite](https://www.pyopensci.org/python-package-guide/tests/index.html) 
+* [Basic setup for Continuous Integration and Deployment (CI/CD)](https://www.pyopensci.org/python-package-guide/continuous-integration/ci.html)
+* [Basic documentation infrastructure and files](https://www.pyopensci.org/python-package-guide/documentation/index.html) using mkdocs or sphinx
 
-If you're interested in using the template, check out the [Copier Template Repo](https://github.com/pyOpenSci/pyos-template).
+If you're interested in using the template, check out the [Copier Template Repo](https://github.com/pyOpenSci/pyos-package-template).
 
----
 
 ## 📘 Learn More About Python Packaging
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,30 @@
 ## What does pyospackage do?
 pyospackage is a demonstration Python package that compliments the pyOpenSci [beginner tutorial series on creating a Python package](https://www.pyopensci.org/python-package-guide/tutorials/intro.html).
 
+## 🔧 About This Template
+
+This package was built using [pyOpenSci’s Copier template](https://github.com/pyOpenSci/pyos-template), which helps ensure consistency, best practices, and ease of maintenance across scientific Python packages.
+
+The template includes configuration for:
+- Standard Python packaging layout
+- Code linting and formatting tools like Ruff
+- Testing setup
+- CI/CD scaffolding
+- Contribution guidelines
+
+If you're interested in using the template, check out the [Copier Template Repo](https://github.com/pyOpenSci/pyos-template).
+
+---
+
+## 📘 Learn More About Python Packaging
+
+This package accompanies our tutorials and docs on building and publishing high-quality Python packages:
+
+- 📦 **Tutorial Series:** [Beginner Python Packaging Tutorials](https://www.pyopensci.org/python-package-guide/tutorials/index.html)
+- 📖 **Overview:** [Python Packaging Overview](https://www.pyopensci.org/python-package-guide/overview.html)
+
+These resources cover everything from package layout and versioning to testing, publishing to PyPI, and creating great documentation.
+
 **Table of Contents**
 
 - [Installation](#installation)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This package was built using [pyOpenSci’s Python package Copier template](http
 The template includes configuration for:
 * [Standard Python package layout and structure](https://www.pyopensci.org/python-package-guide/package-structure-code/python-package-structure.html)
 * [Code linting and formatting tools like Ruff](https://www.pyopensci.org/python-package-guide/package-structure-code/code-style-linting-format.html)
-* [Setup for a test suite](https://www.pyopensci.org/python-package-guide/tests/index.html) 
+* [Setup for a test suite](https://www.pyopensci.org/python-package-guide/tests/index.html)
 * [Basic setup for Continuous Integration and Deployment (CI/CD)](https://www.pyopensci.org/python-package-guide/continuous-integration/ci.html)
 * [Basic documentation infrastructure and files](https://www.pyopensci.org/python-package-guide/documentation/index.html) using mkdocs or sphinx
 


### PR DESCRIPTION
This PR updates the readme file to provide a brief overview of both the copier template and
with links to the [packaging tutorials](https://www.pyopensci.org/python-package-guide/tutorials/create-python-package.html) and [overview pages](https://www.pyopensci.org/python-package-guide/) in our python package guide. Also, 
Improves discoverability of pyOpenSci educational resources.